### PR TITLE
Fix broken URI in reconciliation 0.2 specs

### DIFF
--- a/reconciliation/CG-FINAL-specs-0.2-20230410/index.html
+++ b/reconciliation/CG-FINAL-specs-0.2-20230410/index.html
@@ -112,7 +112,7 @@ dd{margin-left:0}
         W3C Entity Reconciliation Community Group.
         It is intended as a comprehensive and definitive specification of this API in its given state.
 	Various aspects of this API need to be improved, as hinted by notes throughout this document.">
-<link rel="canonical" href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.1-20230410/">
+<link rel="canonical" href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/">
 <script type="application/ld+json">{
   "@context": [
     "http://schema.org",
@@ -135,7 +135,7 @@ dd{margin-left:0}
       }
     }
   ],
-  "id": "https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.1-20230410/",
+  "id": "https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/",
   "type": [
     "TechArticle"
   ],
@@ -588,8 +588,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "wg": "Entity Reconciliation Community Group",
   "wgPublicList": "public-reconciliation",
   "wgURI": "https://www.w3.org/community/reconciliation/",
-  "canonicalURI": "https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.1-20230410/",
-  "latestVersion": "https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.1-20230410/",
+  "canonicalURI": "https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/",
+  "latestVersion": "https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/",
   "edDraftURI": "https://reconciliation-api.github.io/specs/draft/",
   "prevRecURI": "https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.1-20230321/",
   "license": "w3c-software-doc",
@@ -662,7 +662,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/">https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.1-20230410/">https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.1-20230410/</a>
+              <a href="https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/">https://www.w3.org/community/reports/reconciliation/CG-FINAL-specs-0.2-20230410/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://reconciliation-api.github.io/specs/draft/">https://reconciliation-api.github.io/specs/draft/</a></dd>
       


### PR DESCRIPTION
Sorry, I did not check it carefully enough and inserted wrong URIs.