### PR TITLE
Correct latest published version in YAML-LD Final Report.

### DIFF
--- a/json-ld/CG-FINAL-yaml-ld-20231206/index.html
+++ b/json-ld/CG-FINAL-yaml-ld-20231206/index.html
@@ -322,7 +322,7 @@ dd{margin-left:0}
       YAML as a more concise format for representing information
       previously serialized as JSON, including Linked Data, has led to
       the development of YAML-LD.">
-<link rel="canonical" href="https://www.w3.org/community/reports/json-ld/yaml-ld/">
+<link rel="canonical" href="https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/">
 <script type="application/ld+json">{
   "@context": [
     "http://schema.org",
@@ -345,7 +345,7 @@ dd{margin-left:0}
       }
     }
   ],
-  "id": "https://www.w3.org/community/reports/json-ld/yaml-ld/",
+  "id": "https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/",
   "type": [
     "TechArticle"
   ],
@@ -907,7 +907,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "copyrightStart": "2020",
   "shortName": "yaml-ld",
   "edDraftURI": "https://json-ld.github.io/yaml-ld/",
-  "latestVersion": "https://www.w3.org/community/reports/json-ld/yaml-ld/",
+  "latestVersion": "https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/",
   "github": {
     "repoURL": "https://github.com/json-ld/yaml-ld/",
     "branch": "main"
@@ -989,7 +989,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/">https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/community/reports/json-ld/yaml-ld/">https://www.w3.org/community/reports/json-ld/yaml-ld/</a>
+              <a href="https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/">https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://json-ld.github.io/yaml-ld/">https://json-ld.github.io/yaml-ld/</a></dd>
       <dt>Test suite:</dt><dd><a href="https://json-ld.github.io/yaml-ld/tests/">https://json-ld.github.io/yaml-ld/tests/</a></dd>


### PR DESCRIPTION
Report was mistakenly published with a non-timestamped latest published version. This corrects it to use the timestamped version.