### PR TITLE
Add overlooked participant to acknowledgements

### DIFF
--- a/immersive-captions/CG-FINAL-360-captions-20240412/index.html
+++ b/immersive-captions/CG-FINAL-360-captions-20240412/index.html
@@ -356,6 +356,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 				<p>Contributing participants:</p>
 				<ul>
 					<li>Bill Curtis-Davidson, Partnership on Employment &amp; Accessible Technology (Cadmus Group)</li>
+					<li>Brenden Gilbert, Meta</li>
 					<li>Chris Hainsworth, Blind Burners</li>
 					<li>Chris Hughes, University of Salford</li>
 					<li>Delbert Whetter, Exodus Film Group</li>


### PR DESCRIPTION
A participant noticed after publication that their name had not been included in the acknowledgements. I validated with the CG chair that they were an active participant, so this PR adds their name.

I hope this can be treated as editorial and not require a change of the dated publication URI, which is now being disseminated.