### PR TITLE
Small post-publication tweak for Touch Events final report

### DIFF
--- a/touchevents/CG-FINAL-touch-events-20240704/index.html
+++ b/touchevents/CG-FINAL-touch-events-20240704/index.html
@@ -168,10 +168,12 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <script id="initialUserConfig" type="application/json">{
   "specStatus": "CG-FINAL",
   "shortName": "touch-events",
+  "publishDate": "2024-07-04",
   "previousPublishDate": "2013-10-10",
   "previousMaturity": "REC",
   "edDraftURI": "https://w3c.github.io/touch-events/",
   "license": "w3c-software-doc",
+  "latestVersion": "https://www.w3.org/community/reports/touchevents/CG-FINAL-touch-events-20240704/",
   "editors": [
     {
       "name": "Doug Schepers",
@@ -253,7 +255,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/touchevents/CG-FINAL-touch-events-20240704/">https://www.w3.org/community/reports/touchevents/CG-FINAL-touch-events-20240704/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/community/reports/touchevents/touch-events/">https://www.w3.org/community/reports/touchevents/touch-events/</a>
+              <a href="https://www.w3.org/community/reports/touchevents/CG-FINAL-touch-events-20240704/">https://www.w3.org/community/reports/touchevents/CG-FINAL-touch-events-20240704/</a>
             </dd>
       <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/touch-events/">https://w3c.github.io/touch-events/</a></dd>
       


### PR DESCRIPTION
Just noticed that on https://www.w3.org/community/reports/touchevents/CG-FINAL-touch-events-20240704/ under "Latest published version" it incorrectly links to https://www.w3.org/community/reports/touchevents/touch-events/ ... this fixes it (now that the final URL is actually published)

/cc @dontcallmedom 