### PR TITLE
Update latest version and editor draft links

### DIFF
--- a/publishingcg/CG-FINAL-a11y-display-guidelines-20250422/index.html
+++ b/publishingcg/CG-FINAL-a11y-display-guidelines-20250422/index.html
@@ -225,8 +225,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "group": "publishingcg",
   "specStatus": "CG-FINAL",
   "noRecTrack": true,
-  "latestVersion": "https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/latest/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/",
   "canonicalURI": "https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/",
   "editors": [
     {
@@ -300,9 +300,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-a11y-display-guidelines-20250422/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-a11y-display-guidelines-20250422/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/">https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/latest/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/">https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/guidelines/</a></dd>
+      <dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-a11y-display-guidelines-20251222/index.html
+++ b/publishingcg/CG-FINAL-a11y-display-guidelines-20251222/index.html
@@ -226,8 +226,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "group": "publishingcg",
   "specStatus": "CG-FINAL",
   "noRecTrack": true,
-  "latestVersion": "https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/metadata-display-guide/guidelines/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/latest/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/",
   "canonicalURI": "https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/",
   "editors": [
     {
@@ -301,9 +301,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-a11y-display-guidelines-20251222/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-a11y-display-guidelines-20251222/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/">https://www.w3.org/publishing/a11y/metadata-display-guide/guidelines/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/latest/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/metadata-display-guide/guidelines/">https://w3c.github.io/publ-a11y/metadata-display-guide/guidelines/</a></dd>
+      <dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/guidelines/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-audio-playback-20230314/index.html
+++ b/publishingcg/CG-FINAL-audio-playback-20230314/index.html
@@ -115,8 +115,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 </style>
 <script id="initialUserConfig" type="application/json">{
   "group": "publishingcg",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/drafts/audio-playback/",
-  "latestVersion": "https://www.w3.org/publishing/a11y/audio-playback/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/audio-playback/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/audio-playback/latest/",
   "specStatus": "CG-FINAL",
   "shortName": "audio-playback",
   "noRecTrack": true,
@@ -160,9 +160,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-audio-playback-20230314/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-audio-playback-20230314/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/audio-playback/">https://www.w3.org/publishing/a11y/audio-playback/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/audio-playback/latest/">https://w3c-cg.github.io/publ-a11y/audio-playback/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/drafts/audio-playback/">https://w3c.github.io/publ-a11y/drafts/audio-playback/</a></dd>
+    	<dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/audio-playback/">https://w3c-cg.github.io/publ-a11y/audio-playback/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-crosswalk-20260128/index.html
+++ b/publishingcg/CG-FINAL-crosswalk-20260128/index.html
@@ -178,8 +178,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "previousPublishDate": "2024-09-06",
   "previousMaturity": "CG-FINAL",
   "shortName": "crosswalk",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/metadata-crosswalk/",
-  "latestVersion": "https://www.w3.org/2021/a11y-discov-vocab/latest/crosswalk/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/",
   "thisVersion": "https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260128/",
   "editors": [
     {
@@ -263,9 +263,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260128/">https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260128/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/crosswalk/">https://www.w3.org/2021/a11y-discov-vocab/latest/crosswalk/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/">https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/metadata-crosswalk/">https://w3c.github.io/publ-a11y/metadata-crosswalk/</a></dd>
+      <dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/">https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-crosswalk-20260326/index.html
+++ b/publishingcg/CG-FINAL-crosswalk-20260326/index.html
@@ -260,7 +260,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
     </p>
     <dl>
       <dt>This version:</dt><dd>
-              <a class="u-url" href="https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260326/">https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260326/</a>
+              <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-crosswalk-20260326/">https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260326/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
       	<a href="https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/">https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/</a>

--- a/publishingcg/CG-FINAL-crosswalk-20260326/index.html
+++ b/publishingcg/CG-FINAL-crosswalk-20260326/index.html
@@ -180,7 +180,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "shortName": "crosswalk",
   "edDraftURI": "https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/",
   "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/",
-  "thisVersion": "https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260326/",
+  "thisVersion": "https://www.w3.org/community/reports/publishingcg/CG-FINAL-crosswalk-20260326/",
   "editors": [
     {
       "name": "Madeleine Rothberg",

--- a/publishingcg/CG-FINAL-crosswalk-20260326/index.html
+++ b/publishingcg/CG-FINAL-crosswalk-20260326/index.html
@@ -178,8 +178,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "previousPublishDate": "2026-01-28",
   "previousMaturity": "CG-FINAL",
   "shortName": "crosswalk",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/metadata-crosswalk/",
-  "latestVersion": "https://www.w3.org/2021/a11y-discov-vocab/latest/crosswalk/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/",
   "thisVersion": "https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260326/",
   "editors": [
     {
@@ -263,9 +263,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260326/">https://www.w3.org/community/reports/publisingcg/CG-FINAL-crosswalk-20260326/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/crosswalk/">https://www.w3.org/2021/a11y-discov-vocab/latest/crosswalk/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/">https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/metadata-crosswalk/">https://w3c.github.io/publ-a11y/metadata-crosswalk/</a></dd>
+    	<dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/">https://w3c-cg.github.io/publ-a11y/metadata-crosswalk/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-epub-techniques-20250422/index.html
+++ b/publishingcg/CG-FINAL-epub-techniques-20250422/index.html
@@ -183,8 +183,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "group": "publishingcg",
   "specStatus": "CG-FINAL",
   "noRecTrack": true,
-  "latestVersion": "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/latest/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/a11y-meta-display-guide/techniques/epub/",
   "canonicalURI": "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/",
   "editors": [
     {
@@ -223,9 +223,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-epub-techniques-20250422/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-publ-a11y-20250422/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/">https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/latest/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/">https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/epub-metadata/</a></dd>
+    	<dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-epub-techniques-20251222/index.html
+++ b/publishingcg/CG-FINAL-epub-techniques-20251222/index.html
@@ -184,8 +184,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "group": "publishingcg",
   "specStatus": "CG-FINAL",
   "noRecTrack": true,
-  "latestVersion": "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/metadata-display-guide/techniques/epub/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/latest/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/",
   "canonicalURI": "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/",
   "editors": [
     {
@@ -224,9 +224,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-epub-techniques-20251222/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-epub-techniques-20251222/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/">https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/epub/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/latest/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/metadata-display-guide/techniques/epub/">https://w3c.github.io/publ-a11y/metadata-display-guide/techniques/epub/</a></dd>
+    	<dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/epub/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-onix-techniques-20250422/index.html
+++ b/publishingcg/CG-FINAL-onix-techniques-20250422/index.html
@@ -185,8 +185,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "group": "publishingcg",
   "specStatus": "CG-FINAL",
   "noRecTrack": true,
-  "latestVersion": "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/latest/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/",
   "canonicalURI": "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/",
   "editors": [
     {
@@ -236,9 +236,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       	<a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-onix-techniques-20250422/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-onix-techniques-20250422/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/">https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/latest/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/">https://w3c.github.io/publ-a11y/a11y-meta-display-guide/2.0/draft/techniques/onix-metadata/</a></dd>
+    	<dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-onix-techniques-20251222/index.html
+++ b/publishingcg/CG-FINAL-onix-techniques-20251222/index.html
@@ -186,8 +186,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   "group": "publishingcg",
   "specStatus": "CG-FINAL",
   "noRecTrack": true,
-  "latestVersion": "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/metadata-display-guide/techniques/onix/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/latest/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/",
   "canonicalURI": "https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/",
   "editors": [
     {
@@ -237,9 +237,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-onix-techniques-20251222/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-onix-techniques-20251222/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/">https://www.w3.org/publishing/a11y/metadata-display-guide/techniques/onix/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/latest/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/metadata-display-guide/techniques/onix/">https://w3c.github.io/publ-a11y/metadata-display-guide/techniques/onix/</a></dd>
+    	<dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/">https://w3c-cg.github.io/publ-a11y/metadata-display-guide/techniques/onix/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-page-source-id-20230314/index.html
+++ b/publishingcg/CG-FINAL-page-source-id-20230314/index.html
@@ -183,8 +183,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 </style>
 <script id="initialUserConfig" type="application/json">{
   "group": "publishingcg",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/drafts/page-source-id/",
-  "latestVersion": "https://www.w3.org/publishing/a11y/page-source-id/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/page-source-id/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/page-source-id/latest/",
   "specStatus": "CG-FINAL",
   "shortName": "page-source-id",
   "noRecTrack": true,
@@ -233,9 +233,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-page-source-id-20230314/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-page-source-id-20230314/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/page-source-id/">https://www.w3.org/publishing/a11y/page-source-id/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/page-source-id/latest/">https://w3c-cg.github.io/publ-a11y/page-source-id/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/drafts/page-source-id/">https://w3c.github.io/publ-a11y/drafts/page-source-id/</a></dd>
+    	<dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/page-source-id/">https://w3c-cg.github.io/publ-a11y/page-source-id/</a></dd>
       
       
       

--- a/publishingcg/CG-FINAL-schema-a11y-summary-20230516/index.html
+++ b/publishingcg/CG-FINAL-schema-a11y-summary-20230516/index.html
@@ -180,8 +180,8 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <script id="initialUserConfig" type="application/json">{
   "group": "publishingcg",
   "shortName": "schema-a11y-summary",
-  "edDraftURI": "https://w3c.github.io/publ-a11y/drafts/schema-a11y-summary/",
-  "latestVersion": "https://www.w3.org/publishing/a11y/schema-a11y-summary/",
+  "edDraftURI": "https://w3c-cg.github.io/publ-a11y/schema-a11y-summary/",
+  "latestVersion": "https://w3c-cg.github.io/publ-a11y/schema-a11y-summary/latest/",
   "specStatus": "CG-FINAL",
   "noRecTrack": true,
   "copyrightStart": "2022",
@@ -236,9 +236,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
               <a class="u-url" href="https://www.w3.org/community/reports/publishingcg/CG-FINAL-schema-a11y-summary-20230516/">https://www.w3.org/community/reports/publishingcg/CG-FINAL-schema-a11y-summary-20230516/</a>
             </dd>
       <dt>Latest published version:</dt><dd>
-              <a href="https://www.w3.org/publishing/a11y/schema-a11y-summary/">https://www.w3.org/publishing/a11y/schema-a11y-summary/</a>
+      	<a href="https://w3c-cg.github.io/publ-a11y/schema-a11y-summary/latest/">https://w3c-cg.github.io/publ-a11y/schema-a11y-summary/latest/</a>
             </dd>
-      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/publ-a11y/drafts/schema-a11y-summary/">https://w3c.github.io/publ-a11y/drafts/schema-a11y-summary/</a></dd>
+    	<dt>Latest editor's draft:</dt><dd><a href="https://w3c-cg.github.io/publ-a11y/schema-a11y-summary/">https://w3c-cg.github.io/publ-a11y/schema-a11y-summary/</a></dd>
       
       
       


### PR DESCRIPTION
This preps the previously published reports for changes to the publ-a11y repository and latest version links.

These changes should be merged after the publ-a11y repository moves organizations and the existing w3.org redirects are updated.